### PR TITLE
Fix API error handling

### DIFF
--- a/run.py
+++ b/run.py
@@ -22,7 +22,9 @@ def __api__(end_point, args, api_url=API_BASE_URL):
     if response.status_code == 200:
         return response.json()
     else:
-        pass
+        raise requests.HTTPError(
+            f"Request failed with status {response.status_code} for URL: {url}"
+        )
 
 
 parser = argparse.ArgumentParser(description="Process start and end dates.")


### PR DESCRIPTION
## Summary
- raise `requests.HTTPError` when API response status is not 200

## Testing
- `python -m py_compile run.py`